### PR TITLE
Fix Uncaught Error: Class 'Symfony\Component\Process\ProcessBuilder' not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.0.0-alpha.2 - 2018-11-26
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#7](https://github.com/zendframework/zend-coding-standard/pull/7) updates to composer-installer 0.5 which fixes a 'Class not found' error during installation.
+
 ## 2.0.0-alpha.1 - 2018-11-18
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^7.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
         "slevomat/coding-standard": "^4.8.0",
         "squizlabs/php_codesniffer": "^3.3.2",
         "webimpress/coding-standard": "dev-master"


### PR DESCRIPTION
Update to composer-installer 0.5 which fixes an issue where the Class 'Symfony\Component\Process\ProcessBuilder' is not found.