### PR TITLE
Added more simple sniffs to the Zend Coding Standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.0.0-alpha.3 - TBD
+
+### Added
+
+- [#8](https://github.com/zendframework/zend-coding-standard/pull/8) adds some sniffs from webimpress/coding-standard.
+
+  - Forbid null values for class properties
+  - Comments at the end of the line, with at least single space
+  - Requires one space after namespace keyword
+  - One space after break/continue with argument, remove redundant 1
+  - Forbid continue in switch; use break instead
+  - Require camelCase variable names
+  - Detects for-loops that can be simplified to a while-loop
+  - Detects unconditional if- and elseif-statements
+  - Forbid goto instruction
+  - Forbid multiple traits by declaration
+  - Require lowercase function and const keywords in imports with one space after
+  - Forbid superfluous leading backslash in use statements
+  - Forbid whitespace around double colon operator
+  - Forbid whitespace around double colon operator
+
+### Changed
+
+- [#8](https://github.com/zendframework/zend-coding-standard/pull/8) replaces sniffs in favor of webimpress/coding-standard as these are more reliable or fixes more cases.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.0.0-alpha.2 - 2018-11-26
 
 ### Added

--- a/docs/book/v2/coding-style-guide.md
+++ b/docs/book/v2/coding-style-guide.md
@@ -1,10 +1,10 @@
 # Zend Framework Coding Style Guide
 
-This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
-the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1), 
+This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md),
+the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1),
 the basic coding standard.
 
-> Note: PSR-12 is not finalized. e.g. The `!` operator and `:` placement for return values are still under discussion. 
+> Note: PSR-12 is not finalized. e.g. The `!` operator and `:` placement for return values are still under discussion.
 We will change these rules, and, when PSR-12 is finalized, adapt them.
 
 ## General
@@ -12,12 +12,12 @@ We will change these rules, and, when PSR-12 is finalized, adapt them.
 ### Basic Coding Standard
 
 Code MUST follow all rules outlined in [PSR-1](https://www.php-fig.org/psr/psr-1) and
-[PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), except in 
+[PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), except in
 specific cases outlined in this specification, until PSR-12 is accepted as a standard.
 
 ### Indenting and Alignment
 
-- There should be one space on either side of an equals sign used to assign a value to a variable. In case of a 
+- There should be one space on either side of an equals sign used to assign a value to a variable. In case of a
   block of related assignments, more space may be inserted before the equal sign to promote readability.
   [*](ruleset.md#genericformattingmultiplestatementalignment)
 
@@ -43,7 +43,7 @@ $array = [
     'key1'      => 'value1',
     'key2'      => 'value2',
     'keyTwenty' => 'value3',
-]; 
+];
 
 $var = [
     'one'   => function() {
@@ -72,13 +72,13 @@ $var = [
 - Comments may be omitted and should not be used for typehinted arguments.
 - Comments may not start with `#`. [*](ruleset.md#pearcommentinginlinecomment)
 - Comments may not be empty. [*](ruleset.md#slevomatcodingstandardcommentingemptycomment)
-- The words _private_, _protected_, _static_, _constructor_, _deconstructor_, _Created by_, _getter_ and _setter_, 
+- The words _private_, _protected_, _static_, _constructor_, _deconstructor_, _Created by_, _getter_ and _setter_,
   may not be used in comments. [*](ruleset.md#slevomatcodingstandardcommentingforbiddencomments)
 - The annotations `@api`, `@author`, `@category`, `@created`, `@package`, `@subpackage` and `@version` may not
   be used in comments. Git commits provide accurate information. [*](ruleset.md#slevomatcodingstandardcommentingforbiddenannotations)
 - The asterisks in a doc comment should align, and there should be one space between the asterisk and tag.
   [*](ruleset.md#squizcommentingdoccommentalignment)
-- Comment tags `@param`, `@throws` and `@return` should not be aligned or contain multiple spaces between the tag, 
+- Comment tags `@param`, `@throws` and `@return` should not be aligned or contain multiple spaces between the tag,
   type and description. [*](ruleset.md#squizcommentingfunctioncomment)
 - If a function throws any exceptions, they should be documented in `@throws` tags.
   [*](ruleset.md#squizcommentingfunctioncomment)
@@ -93,12 +93,12 @@ In addition to [PSR-12](https://github.com/php-fig/fig-standards/blob/master/pro
 - Each PHP file should have a page level docblock with `@see`, `@copyright` and `@license`. The copyright date should
   only be adjusted if the file has changed.
 - Each PHP file should have a strict type declaration at the top after the page level docblock. [*](ruleset.md#slevomatcodingstandardtypehintsdeclarestricttypes)
-- Import statements should be alphabetically sorted. [*](ruleset.md#slevomatcodingstandardnamespacesalphabeticallysorteduses)
+- Import statements should be alphabetically sorted. [*](ruleset.md#webimpresscodingstandardphpinstantiatingparenthesis)
 - Import statements should not be grouped. [*](ruleset.md#slevomatcodingstandardnamespacesdisallowgroupuse)
 - Each import statement should be on its own line. [*](ruleset.md#slevomatcodingstandardnamespacesmultipleusesperline)
 - Absolute class name references, functions and constants should be imported. [*](ruleset.md#slevomatcodingstandardnamespacesreferenceusednamesonly)
-- Unused import statements are not allowed. [*](ruleset.md#slevomatcodingstandardnamespacesunuseduses)
-- Classes and function within the same namespace should not be imported. [*](ruleset.md#slevomatcodingstandardnamespacesusefromsamenamespace)
+- Unused import statements are not allowed. [*](ruleset.md#webimpresscodingstandardnamespacesunusedusestatement)
+- Classes and function within the same namespace should not be imported. [*](ruleset.md#webimpresscodingstandardnamespacesunusedusestatement)
 - Imports should not have an alias with the same name. [*](ruleset.md#slevomatcodingstandardnamespacesuselessalias)
 - A class should not have unused private constants, (or write-only) properties and methods. [*](ruleset.md#slevomatcodingstandardclassesunusedprivateelements)
 
@@ -137,10 +137,10 @@ class FooBar
 
 In addition to [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#4-classes-properties-and-methods):
 
-- Class name resolution via `::class` should be used instead of `__CLASS__`, `get_class()`, `get_class($this)`, 
+- Class name resolution via `::class` should be used instead of `__CLASS__`, `get_class()`, `get_class($this)`,
   `get_called_class()` and `get_parent_class()`. [*](ruleset.md#slevomatcodingstandardclassesmodernclassnamereference)
 - Methods may not have the final declaration in classes declared as final. [*](ruleset.md#genericcodeanalysisunnecessaryfinalmodifier)
-- The colon used with return type declarations MUST be surrounded with 1 space. [*](ruleset.md#slevomatcodingstandardtypehintsreturntypehintspacing)
+- The colon used with return type declarations MUST be surrounded with 1 space. [*](ruleset.md#webimpresscodingstandardformattingreturntype)
 - Nullable and optional arguments, which are marked as `= null`, must have the `?` symbol present. [*](ruleset.md#slevomatcodingstandardtypehintsnullabletypefornulldefaultvalue)
 
 ```php
@@ -158,16 +158,16 @@ class ClassName extends ParentClass implements ArrayAccess, Countable
     use FirstTrait;
     use SecondTrait;
     use ThirdTrait;
-    
+
     public const CONSTANT = 'constant';
-    
+
     private $property;
-    
+
     public function fooBarBaz(int $arg1, &$arg2, array $arg3 = [], ?$arg4 = null) : void
     {
         return;
     }
-    
+
     public function aVeryLongMethodName(
         FirstInterface $arg1,
         &$arg2,
@@ -367,7 +367,7 @@ $instance = new class extends Foo implements
 - Short list syntax `[...]` should be used instead of `list(...)`. [*](ruleset.md#slevomatcodingstandardphpshortlist)
 - Short form of type keywords must be used. i.e. `bool` instead of `boolean`, `int` instead of `integer`, etc.
   The `binary` and `unset` cast operators are not allowed. [*](ruleset.md#slevomatcodingstandardphptypecast)
-- Parentheses should not be used if they can be omitted. [*](ruleset.md#slevomatcodingstandardphpuselessparentheses)
+- Parentheses should not be used if they can be omitted. [*](ruleset.md#webimpresscodingstandardformattingunnecessaryparentheses)
 - Semicolons `;` should not be used if they can be omitted. [*](ruleset.md#slevomatcodingstandardphpuselesssemicolon)
 - Variables should be returned directly instead of assigned to a variable which is not used. [*](ruleset.md#slevomatcodingstandardvariablesuselessvariable)
 - The `self` keyword should be used instead of the current class name, and should not have spaces around `::`.
@@ -376,8 +376,8 @@ $instance = new class extends Foo implements
 - Double quote strings may only be used if they contain variables. [*](ruleset.md#squizstringsdoublequoteusage)
 - Strings should not be enclosed in parentheses when being echoed. [*](ruleset.md#squizstringsechoedstrings)
 - Type casts should not have whitespace inside the parentheses. [*](ruleset.md#squizwhitespacecastspacing)
-- The opening brace for functions should be on a new line with no blank lines surrounding it. [*](ruleset.md#squizwhitespacefunctionopeningbracespace)
-- The PHP constructs `echo`, `print`, `return`, `include`, `include_once`, `require`, `require_once`, and `new`, should 
+- The opening brace for functions should be on a new line with no blank lines surrounding it. [*](ruleset.md#webimpresscodingstandardwhitespacebraceblankline)
+- The PHP constructs `echo`, `print`, `return`, `include`, `include_once`, `require`, `require_once`, and `new`, should
   have one space after them. [*](ruleset.md#squizwhitespacelanguageconstructspacing)
 - The object operator `->` should not have any spaces around it. [*](ruleset.md#squizwhitespaceobjectoperatorspacing)
 - Semicolons should not have spaces before them. [*](ruleset.md#squizwhitespacesemicolonspacing)

--- a/docs/book/v2/ruleset.md
+++ b/docs/book/v2/ruleset.md
@@ -21,17 +21,8 @@ Short array syntax must be used to define arrays.
 $foo = ['foo' => 'bar'];
 ```
 
-### Generic.PHP.BacktickOperator
-The backtick operator may not be used for execution of shell commands.
-
-*Invalid: Using the backtick operator.*
-```php
-<?php
-$output = `ls -al`;
-```
-
 ### Generic.Classes.DuplicateClassName
-Class and Interface names should be unique in a project and must have a unique fully qualified name. They should never 
+Class and Interface names should be unique in a project and must have a unique fully qualified name. They should never
 be duplicated.
 
 *Valid: Unique class names.*
@@ -76,7 +67,7 @@ Control Structures must have at least one statement inside of the body.
 *Valid:*
 ```php
 <?php
-for ($i; $i > 0; $i--) { 
+for ($i; $i > 0; $i--) {
     echo 'hello';
 }
 ```
@@ -251,6 +242,15 @@ class Foo
 }
 ```
 
+### Generic.PHP.BacktickOperator
+The backtick operator may not be used for execution of shell commands.
+
+*Invalid: Using the backtick operator.*
+```php
+<?php
+$output = `ls -al`;
+```
+
 ### Generic.PHP.CharacterBeforePHPOpeningTag
 The opening PHP tag should be the first item in the file.
 
@@ -284,8 +284,11 @@ $foo = split('a', $bar);
 
 ### Generic.PHP.DisallowShortOpenTag
 #### Generic.PHP.DisallowShortOpenTag.EchoFound
-_PSR-1:_ PHP code must use the long `<?php ?>` tags or the short-echo `<?= ?>` tags; it must not use the other tag 
+_PSR-1:_ PHP code must use the long `<?php ?>` tags or the short-echo `<?= ?>` tags; it must not use the other tag
 variations.
+
+### Generic.PHP.DiscourageGoto
+Forbid goto instruction.
 
 ### Generic.PHP.ForbiddenFunctions
 PHP functions which are an alias may not be used. _This can't be fixed automatically and need to be done manually._
@@ -370,32 +373,29 @@ Perl-style `#` comments are not allowed.
 ## SlevomatCodingStandard
 
 ### SlevomatCodingStandard.Arrays.TrailingArrayComma
-All array values must be followed by a comma, including the last value. Commas after last element in an array make 
+All array values must be followed by a comma, including the last value. Commas after last element in an array make
 adding a new element easier and result in a cleaner versioning diff.
 
 ### SlevomatCodingStandard.Classes.ClassConstantVisibility
-_PSR-12:_ Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities 
+_PSR-12:_ Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities
 (PHP 7.1 or later).
 
 ### SlevomatCodingStandard.Classes.ModernClassNameReference
-Class name resolution via `::class` should be used instead of `__CLASS__`, `get_class()`, `get_class($this)`, 
+Class name resolution via `::class` should be used instead of `__CLASS__`, `get_class()`, `get_class($this)`,
 `get_called_class()` and `get_parent_class()`.
-
-### SlevomatCodingStandard.Classes.TraitUseDeclaration
-_PSR-12:_ Each individual Trait that is imported into a class MUST be included one-per-line.
 
 ### SlevomatCodingStandard.Classes.UnusedPrivateElements
 A class should not have unused private constants, (or write-only) properties and methods.
 
 ### SlevomatCodingStandard.Commenting.ForbiddenAnnotations
 The annotations `@api`, `@author`, `@category`, `@created`, `@package`, `@subpackage` and `@version` may not
-be used in comments. Git commits provide accurate information. 
+be used in comments. Git commits provide accurate information.
 
 ### SlevomatCodingStandard.Commenting.EmptyComment
 Comments may not be empty.
 
 ### SlevomatCodingStandard.Commenting.ForbiddenComments
-To keep comments clean, the words _private_, _protected_, _static_, _constructor_, _deconstructor_, _Created by_, 
+To keep comments clean, the words _private_, _protected_, _static_, _constructor_, _deconstructor_, _Created by_,
 _getter_ and _setter_ may not be used in comments
 
 ### SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration
@@ -407,14 +407,14 @@ class Foo
 {
 	/** @var string */
 	private $foo;
-	
+
 	public function __construct()
 	{
         /** @var string $f */
         foreach ($e as $f) {
             // ...
         }
-        
+
         /** @var string[] $a */
         $a = $this->get();
     }
@@ -441,7 +441,7 @@ private $foo;
 ```
 
 ### SlevomatCodingStandard.ControlStructures.DisallowEqualOperators
-Loose `==` and `!=` comparison operators should not be used. Use strict comparison `===` and `!==` instead, they are 
+Loose `==` and `!=` comparison operators should not be used. Use strict comparison `===` and `!==` instead, they are
 much more secure and predictable.
 
 *Valid: Strict comparison is used.*
@@ -490,10 +490,6 @@ yield([]);
 throw(new Exception());
 exit();
 ```
-
-### SlevomatCodingStandard.ControlStructures.NewWithParentheses
-_PSR-12:_ When instantiating a new class, parenthesis MUST always be present even when there are no arguments passed to 
-the constructor.
 
 *Valid: Parenthesis are used for instantiating a new class.*
 ```php
@@ -591,25 +587,6 @@ $closure = function (string $arg1, string $arg2) use ($var1, $var2) : string {
 };
 ```
 
-### SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses
-Import statements should be alphabetically sorted.
-
-*Valid: The import statements are sorted alphabetically.*
-```php
-<?php
-use Example\A;
-use Example\B;
-use Vendor\Package\C;
-```
-
-*Invalid: The import statements are in a random order.*
-```php
-<?php
-use Example\A;
-use Vendor\Package\C;
-use Example\B;
-```
-
 ### SlevomatCodingStandard.Namespaces.DisallowGroupUse
 Import statements should not be grouped.
 
@@ -650,15 +627,6 @@ Require newlines around namespace declaration
 ### SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
 Absolute class name references, functions and constants should be imported.
 
-### SlevomatCodingStandard.Namespaces.UnusedUses
-Unused import statements are not allowed.
-
-### SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash
-_PSR-12:_ Import statements MUST never begin with a leading backslash as they must always be fully qualified.
-
-### SlevomatCodingStandard.Namespaces.UseFromSameNamespace
-Classes and function within the same namespace should not be imported.
-
 *Valid: `Bar` is not imported.*
 ```php
 <?php
@@ -684,16 +652,13 @@ class Foo extends Bar
 }
 ```
 
-### SlevomatCodingStandard.Namespaces.UseSpacing
-_PSR-12:_ Require empty newlines before and after uses
-
 ### SlevomatCodingStandard.Namespaces.UselessAlias
 Imports should not have an alias with the same name.
 
 *Valid: The alias and imported class name are different.*
 ```php
 <?php
-use Foo\Bar as MyBar; 
+use Foo\Bar as MyBar;
 ```
 
 *Invalid: Alias has same name as imported class.*
@@ -762,31 +727,6 @@ declare(strict_types=1);
 // ...
 ```
 
-### SlevomatCodingStandard.PHP.UselessParentheses
-Parentheses should not be used if they can be omitted.
-
-*Valid: No parentheses used.*
-```php
-<?php
-$x = $y !== null ? true : false;
-$a = $b ? 1 : 0;
-$c = $d ? 1 : 0;
-$x = self::$a;
-$x = Something\Anything::$a;
-$x = self::$a::$b;
-```
-
-*Invalid: Unneeded parentheses.*
-```php
-<?php
-$x = ($y !== null) ? true : false;
-$a = ($b) ? 1 : 0;
-$c = (   $d    ) ? 1 : 0;
-$x = (self::$a);
-$x = (Something\Anything::$a);
-$x = (self::$a::$b);
-```
-
 ### SlevomatCodingStandard.PHP.UselessSemicolon
 Semicolons `;` should not be used if they can be omitted.
 
@@ -809,7 +749,7 @@ class Whatever {
 ```
 
 ### SlevomatCodingStandard.TypeHints.LongTypeHints
-Shorthand scalar typehint variants must be used in docblocks: `bool` instead of `boolean`, `int` instead of `integer`, 
+Shorthand scalar typehint variants must be used in docblocks: `bool` instead of `boolean`, `int` instead of `integer`,
 etc. This is for consistency with _PSR-12_ native scalar typehints which also allow shorthand variants only.
 
 ### SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
@@ -830,22 +770,8 @@ function foo(int $foo = null) {
 ```
 
 ### SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing
-_PSR-12:_ Method and function arguments must have one space between typehint and variable. Between the nullability sign 
-and typehint may not be a space. 
-
-### SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing
-The colon used with return type declarations MUST be surrounded with 1 space. This is different with the draft PSR-12 
-proposal and will be adjusted if needed when PSR-12 is accepted.
-```php
-public function foo($bar) : array;
-```
-
-### SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces
-- _PSR-12:_ The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the 
-  next line after the body.
-- _PSR-12:_ Any closing brace MUST NOT be followed by any comment or statement on the same line.
-- _PSR-12:_ Opening braces MUST be on their own line and MUST NOT be preceded or followed by a blank line.
-- _PSR-12:_ Closing braces MUST be on their own line and MUST NOT be preceded by a blank line.
+_PSR-12:_ Method and function arguments must have one space between typehint and variable. Between the nullability sign
+and typehint may not be a space.
 
 ### SlevomatCodingStandard.Variables.UselessVariable
 Variables should be returned directly instead of assigned to a variable which is not used.
@@ -924,7 +850,7 @@ return [
 ```
 
 ### Squiz.Classes.ClassFileName
-_PSR-4:_ The class name must correspond to a file name ending in .php. The file name MUST match the case of the 
+_PSR-4:_ The class name must correspond to a file name ending in .php. The file name MUST match the case of the
 terminating class name.
 
 ### Squiz.Classes.SelfMemberReference
@@ -954,7 +880,7 @@ The asterisks in a doc comment should align, and there should be one space betwe
 <?php
 /**
  * These lines are aligned.
- * 
+ *
  * @var array
  */
 ```
@@ -972,9 +898,9 @@ There should be no multiple spaces between the tag, type and description.
  * This is a summary
  *
  * This is a description.
- * 
+ *
  * @see http://example.com/my/bar URL to documentation.
- * 
+ *
  * @param array $argument1 This is the description.
  * @param string $arg2 This is the description.
  * @param null|string $longerArgument3 This is the description.
@@ -1027,7 +953,7 @@ Force whitespace before and after concatenation
 
 ### Squiz.Strings.DoubleQuoteUsage
 #### Squiz.Strings.DoubleQuoteUsage.ContainsVar
-Double quote strings may only be used if they contain variables. SQL queries containing single quotes are an exception 
+Double quote strings may only be used if they contain variables. SQL queries containing single quotes are an exception
 to the rule.
 
 *Valid: Double quote strings are only used when it contains a variable.*
@@ -1079,29 +1005,8 @@ $foo = (int) '42';
 $foo = ( int ) '42';
 ```
 
-### Squiz.WhiteSpace.FunctionOpeningBraceSpace
-The opening brace for functions should be on a new line with no blank lines surrounding it.
-
-*Valid: Opening brace is on a new line.*
-```php
-<?php
-function foo() : int
-{
-    return 42;
-}
-```
-
-*Invalid: Opening brace is on the same line as the function declaration and a blank line after the opening brace.*
-```php
-<?php
-function foo() {
-
-    return 42;
-}
-```
-
 ### Squiz.WhiteSpace.LanguageConstructSpacing
-The PHP constructs `echo`, `print`, `return`, `include`, `include_once`, `require`, `require_once`, and `new` should 
+The PHP constructs `echo`, `print`, `return`, `include`, `include_once`, `require`, `require_once`, and `new` should
 have one space after them.
 
 *Valid: echo statement with a single space after it.*
@@ -1168,3 +1073,122 @@ echo 'hi' ;
 ### Squiz.WhiteSpace.SuperfluousWhitespace
 #### Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines
 The code should not contain superfluous whitespaces. e.g. multiple empty lines, trailing spaces, etc.
+
+
+
+## WebimpressCodingStandard
+
+### WebimpressCodingStandard.PHP.ImportInternalConstant
+Import internal constants.
+
+### WebimpressCodingStandard.PHP.ImportInternalConstant
+Import internal functions.
+
+### WebimpressCodingStandard.Classes.NoNullValues
+Forbid null values for class properties
+
+### WebimpressCodingStandard.Commenting.Placement
+Comments at the end of the line, with at least single space.
+
+### WebimpressCodingStandard.WhiteSpace.Namespace
+Requires one space after namespace keyword.
+
+### WebimpressCodingStandard.ControlStructures.BreakAndContinue
+One space after break/continue with argument, remove redundant 1.
+
+### WebimpressCodingStandard.ControlStructures.ContinueInSwitch
+Forbid continue in switch; use break instead.
+
+### WebimpressCodingStandard.NamingConventions.ValidVariableName
+Require camelCase variable names.
+
+### Generic.CodeAnalysis.ForLoopShouldBeWhileLoop
+Detects for-loops that can be simplified to a while-loop.
+
+### Generic.CodeAnalysis.UnconditionalIfStatement
+Detects unconditional if- and elseif-statements.
+
+### WebimpressCodingStandard.Classes.AlphabeticallySortedTraits
+Sort traits alphabetically.
+
+### WebimpressCodingStandard.Classes.TraitUsage
+_PSR-12:_ Each individual Trait that is imported into a class MUST be included one-per-line.
+
+### WebimpressCodingStandard.PHP.InstantiatingParenthesis
+_PSR-12:_ When instantiating a new class, parenthesis MUST always be present even when there are no arguments passed to
+the constructor.
+
+### WebimpressCodingStandard.Namespaces.AlphabeticallySortedUses
+Import statements should be alphabetically sorted.
+
+*Valid: The import statements are sorted alphabetically.*
+```php
+<?php
+use Example\A;
+use Example\B;
+use Vendor\Package\C;
+```
+
+*Invalid: The import statements are in a random order.*
+```php
+<?php
+use Example\A;
+use Vendor\Package\C;
+use Example\B;
+```
+
+### WebimpressCodingStandard.Namespaces.ConstAndFunctionKeywords
+Require lowercase function and const keywords in imports with one space after.
+
+### WebimpressCodingStandard.Namespaces.UnusedUseStatement
+Forbid unused use statements.
+Forbid useless uses of the same namespace.
+
+### WebimpressCodingStandard.Namespaces.UseDoesNotStartWithBackslash
+_PSR-12:_ Import statements MUST never begin with a leading backslash as they must always be fully qualified.
+
+### WebimpressCodingStandard.Formatting.UnnecessaryParentheses
+Parentheses should not be used if they can be omitted.
+
+*Valid: No parentheses used.*
+```php
+<?php
+$x = $y !== null ? true : false;
+$a = $b ? 1 : 0;
+$c = $d ? 1 : 0;
+$x = self::$a;
+$x = Something\Anything::$a;
+$x = self::$a::$b;
+```
+
+*Invalid: Unneeded parentheses.*
+```php
+<?php
+$x = ($y !== null) ? true : false;
+$a = ($b) ? 1 : 0;
+$c = (   $d    ) ? 1 : 0;
+$x = (self::$a);
+$x = (Something\Anything::$a);
+$x = (self::$a::$b);
+```
+
+### WebimpressCodingStandard.Formatting.ReturnType
+The colon used with return type declarations MUST be surrounded with 1 space. This is different with the draft PSR-12
+proposal and will be adjusted if needed when PSR-12 is accepted.
+```php
+public function foo($bar) : array;
+```
+
+### WebimpressCodingStandard.WhiteSpace.BraceBlankLine
+- _PSR-12:_ The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the
+  next line after the body.
+- _PSR-12:_ Any closing brace MUST NOT be followed by any comment or statement on the same line.
+- _PSR-12:_ Opening braces MUST be on their own line and MUST NOT be preceded or followed by a blank line.
+- _PSR-12:_ Closing braces MUST be on their own line and MUST NOT be preceded by a blank line.
+- The opening brace for functions should be on a new line with no blank lines surrounding it.
+
+### SlevomatCodingStandard.Namespaces.UseSpacing
+_PSR-12:_ Require empty newlines before and after uses
+
+### WebimpressCodingStandard.Formatting.DoubleColon
+Forbid whitespace around double colon operator.

--- a/src/ZendCodingStandard/ruleset.xml
+++ b/src/ZendCodingStandard/ruleset.xml
@@ -10,6 +10,11 @@
         <exclude name="PSR2.Namespaces.UseDeclaration.SpaceAfterLastUse"/>
         <!-- Checked by SlevomatCodingStandard.Namespaces.NamespaceSpacing -->
         <exclude name="PSR2.Namespaces.NamespaceDeclaration.BlankLineAfter"/>
+        <!-- Checked by WebimpressCodingStandard.WhiteSpace.BraceBlankLine -->
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
+        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
     </rule>
 
     <!-- Force array element indentation with 4 spaces -->
@@ -26,6 +31,36 @@
     <rule ref="WebimpressCodingStandard.Arrays.Format"/>
     <!-- Add trailing commas to all array elements -->
     <rule ref="WebimpressCodingStandard.Arrays.TrailingArrayComma"/>
+    <!-- Forbid blank line after opening braces and before closing braces -->
+    <rule ref="WebimpressCodingStandard.WhiteSpace.BraceBlankLine"/>
+
+    <!-- Import internal constants -->
+    <rule ref="WebimpressCodingStandard.PHP.ImportInternalConstant"/>
+    <!-- Import internal functions -->
+    <rule ref="WebimpressCodingStandard.PHP.ImportInternalFunction"/>
+    <!-- Forbid null values for class properties -->
+    <rule ref="WebimpressCodingStandard.Classes.NoNullValues"/>
+    <!-- Comments at the end of the line, with at least single space -->
+    <rule ref="WebimpressCodingStandard.Commenting.Placement"/>
+
+    <!-- Requires one space after namespace keyword -->
+    <rule ref="WebimpressCodingStandard.WhiteSpace.Namespace"/>
+    <!-- Forbid spaces around namespace separator -->
+    <!-- TODO: Cannot be included because of error in SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly -->
+    <!--<rule ref="WebimpressCodingStandard.WhiteSpace.NamespaceSeparator"/>-->
+
+    <!-- One space after break/continue with argument, remove redundant 1 -->
+    <rule ref="WebimpressCodingStandard.ControlStructures.BreakAndContinue"/>
+    <!-- Forbid continue in switch; use break instead -->
+    <rule ref="WebimpressCodingStandard.ControlStructures.ContinueInSwitch"/>
+
+    <!-- Require camelCase variable names -->
+    <rule ref="WebimpressCodingStandard.NamingConventions.ValidVariableName"/>
+
+    <!-- Detects for-loops that can be simplified to a while-loop -->
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <!-- Detects unconditional if- and elseif-statements -->
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
 
     <!-- Forbid duplicate classes -->
     <rule ref="Generic.Classes.DuplicateClassName"/>
@@ -98,6 +133,8 @@
             </property>
         </properties>
     </rule>
+    <!-- Forbid goto instruction -->
+    <rule ref="Generic.PHP.DiscourageGoto"/>
     <!-- Force PHP 7 param and return types to be lowercased -->
     <rule ref="Generic.PHP.LowerCaseType"/>
     <!-- Forbid `php_sapi_name()` function, use PHP_SAPI -->
@@ -123,17 +160,10 @@
     </rule>
     <!-- Require usage of ::class instead of __CLASS__, get_class(), get_class($this), get_called_class() and get_parent_class() -->
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
-    <!-- Forbid uses of multiple traits separated by comma -->
-    <rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
-    <!-- Require no spaces before trait use, between trait uses and one space after trait uses -->
-    <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
-        <properties>
-            <property name="linesCountAfterLastUse" value="1"/>
-            <property name="linesCountAfterLastUseWhenLastInClass" value="0"/>
-            <property name="linesCountBeforeFirstUse" value="0"/>
-            <property name="linesCountBetweenUses" value="0"/>
-        </properties>
-    </rule>
+    <!-- Sort traits alphabetically -->
+    <rule ref="WebimpressCodingStandard.Classes.AlphabeticallySortedTraits"/>
+    <!-- Forbid multiple traits by declaration -->
+    <rule ref="WebimpressCodingStandard.Classes.TraitUsage"/>
     <!-- Forbid dead code -->
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
     <!-- Forbid useless annotations - Git and LICENCE file provide more accurate information -->
@@ -171,7 +201,7 @@
     <!-- Require language constructs without parentheses -->
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <!-- Require new instances with parentheses -->
-    <rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+    <rule ref="WebimpressCodingStandard.PHP.InstantiatingParenthesis"/>
     <!-- Require usage of null coalesce operator when possible -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <!-- Forbid useless unreachable catch blocks -->
@@ -181,12 +211,13 @@
     <!-- Forbid unused variables passed to closures via `use` -->
     <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
     <!-- Require use statements to be alphabetically sorted -->
-    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
-        <properties>
-            <!-- Force PSR-12 order: classes, functions, constants with 1 emty line in between -->
-            <property name="psr12Compatible" value="true"/>
-        </properties>
-    </rule>
+    <rule ref="WebimpressCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <!-- Require lowercase function and const keywords in imports with one space after -->
+    <rule ref="WebimpressCodingStandard.Namespaces.ConstAndFunctionKeywords"/>
+    <!-- Forbid unused use statements -->
+    <rule ref="WebimpressCodingStandard.Namespaces.UnusedUseStatement"/>
+    <!-- Forbid superfluous leading backslash in use statements -->
+    <rule ref="WebimpressCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <!-- Forbid fancy group uses -->
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <!-- Forbid multiple use statements on same line -->
@@ -207,24 +238,6 @@
             <property name="searchAnnotations" value="true"/>
         </properties>
     </rule>
-    <!-- Forbid unused use statements -->
-    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
-        <properties>
-            <property name="searchAnnotations" value="true"/>
-        </properties>
-    </rule>
-    <!-- Forbid superfluous leading backslash in use statements -->
-    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
-    <!-- Forbid useless uses of the same namespace -->
-    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
-    <!-- Require empty newlines before and after uses -->
-    <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing">
-        <properties>
-            <property name="linesCountAfterLastUse" value="1"/>
-            <property name="linesCountBeforeFirstUse" value="1"/>
-            <property name="linesCountBetweenUseTypes" value="1"/>
-        </properties>
-    </rule>
     <!-- Forbid useless alias for classes, constants and functions -->
     <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <!-- Require the usage of assignment operators, eg `+=`, `.=` when possible -->
@@ -242,7 +255,7 @@
         </properties>
     </rule>
     <!-- Forbid useless parentheses -->
-    <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
+    <rule ref="WebimpressCodingStandard.Formatting.UnnecessaryParentheses"/>
     <!-- Forbid useless semicolon `;` -->
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
     <!-- Require use of short versions of scalar types (i.e. int instead of integer) -->
@@ -252,17 +265,9 @@
     <!-- Require one space between typehint and variable, require no space between nullability sign and typehint -->
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
     <!-- Require space around colon in return types -->
-    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
-        <properties>
-            <property name="spacesCountBeforeColon" value="1"/>
-        </properties>
-    </rule>
-    <!-- Forbid empty lines around type declarations -->
-    <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">
-        <properties>
-            <property name="linesCountAfterOpeningBrace" value="0"/>
-            <property name="linesCountBeforeClosingBrace" value="0"/>
-        </properties>
+    <rule ref="WebimpressCodingStandard.Formatting.ReturnType">
+        <!-- Covered by Generic.PHP.LowerCaseType -->
+        <exclude name="WebimpressCodingStandard.Formatting.ReturnType.LowerCaseSimpleType"/>
     </rule>
     <!-- Forbid useless variables -->
     <rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
@@ -337,8 +342,6 @@
     <rule ref="Squiz.Strings.EchoedStrings"/>
     <!-- Forbid spaces in type casts -->
     <rule ref="Squiz.WhiteSpace.CastSpacing"/>
-    <!-- Forbid blank line after function opening brace -->
-    <rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
     <!-- Require space after language constructs -->
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Require space around logical operators -->
@@ -349,6 +352,8 @@
             <property name="ignoreNewlines" value="true"/>
         </properties>
     </rule>
+    <!-- Forbid whitespace around double colon operator -->
+    <rule ref="WebimpressCodingStandard.Formatting.DoubleColon"/>
     <!-- Forbid multiple spaces before and after operators -->
     <rule ref="Squiz.WhiteSpace.OperatorSpacing">
         <properties>

--- a/test/expected-report.txt
+++ b/test/expected-report.txt
@@ -5,11 +5,14 @@ FILE                                                  ERRORS  WARNINGS
 ----------------------------------------------------------------------
 test/fixable/anonymous-classes.php                    9       0
 test/fixable/array-indentation.php                    39      1
-test/fixable/class-name-resolution.php                12      0
+test/fixable/class-name-resolution.php                13      0
+test/fixable/class-properties.php                     6       0
+test/fixable/classes-traits-interfaces.php            13      0
 test/fixable/closures.php                             19      0
 test/fixable/commenting.php                           17      0
 test/fixable/concatenation-spacing.php                15      0
-test/fixable/example-class.php                        28      0
+test/fixable/control-structures.php                   5       0
+test/fixable/example-class.php                        30      0
 test/fixable/extends-and-implements-multiline.php     10      0
 test/fixable/extends-and-implements.php               5       0
 test/fixable/forbidden-comments.php                   4       0
@@ -18,21 +21,22 @@ test/fixable/LowCaseTypes.php                         2       0
 test/fixable/method-and-function-arguments.php        11      0
 test/fixable/method-and-function-calls.php            13      0
 test/fixable/namespaces-spacing.php                   3       0
-test/fixable/new-with-parentheses.php                 18      0
-test/fixable/not-spacing.php                          7       0
-test/fixable/operators.php                            7       0
+test/fixable/new-with-parentheses.php                 19      0
+test/fixable/not-spacing.php                          14      0
+test/fixable/operators.php                            9       0
 test/fixable/return-type-on-methods.php               17      0
 test/fixable/semicolon-spacing.php                    3       0
-test/fixable/statement-alignment.php                  18      0
+test/fixable/statement-alignment.php                  19      0
 test/fixable/test-case.php                            4       0
-test/fixable/traits-uses.php                          10      0
+test/fixable/traits-uses.php                          9       0
 test/fixable/UnusedVariables.php                      1       0
 test/fixable/useless-semicolon.php                    2       0
+test/fixable/variable-names.php                       5       2
 test/fixable/visibility-declaration.php               1       0
 ----------------------------------------------------------------------
-A TOTAL OF 281 ERRORS AND 1 WARNING WERE FOUND IN 26 FILES
+A TOTAL OF 323 ERRORS AND 3 WARNINGS WERE FOUND IN 30 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 249 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 276 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/test/fixable/anonymous-classes.php
+++ b/test/fixable/anonymous-classes.php
@@ -2,18 +2,20 @@
 
 declare(strict_types=1);
 
-$instance = new class {};
+$instance = new class() {};
 
 // Brace on the same line
-$instance = new class extends \Foo implements \HandleableInterface {
+$instance = new class() extends \Foo implements \HandleableInterface {
     // Class content
 };
 
 // Brace on the next line
-$instance = new class extends \Foo implements
+$instance = new class() extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable
 {
+
     // Class content
+
 };

--- a/test/fixable/class-properties.php
+++ b/test/fixable/class-properties.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+class ClassProperties
+{
+    public $var = null;
+
+    protected $bar = null;
+
+    private $baz = null;
+}

--- a/test/fixable/classes-traits-interfaces.php
+++ b/test/fixable/classes-traits-interfaces.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+class Foo
+{
+
+    public $bar;
+
+}
+
+trait Bar
+{
+
+    public $var;
+
+}
+
+interface Baz
+{
+
+    public function big() : int;
+
+}

--- a/test/fixable/control-structures.php
+++ b/test/fixable/control-structures.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+switch (true) {
+    case $a:
+        continue;
+    case $b:
+        if ($a > 1) {
+            continue;
+        }
+        break 1;
+}
+
+while ($a > 1) {
+    for ($i = $a; $i < $b; ++$i) {
+        if ($i % 2) {
+            continue 1;
+        }
+
+        break   2;
+    }
+}

--- a/test/fixable/extends-and-implements-multiline.php
+++ b/test/fixable/extends-and-implements-multiline.php
@@ -11,7 +11,7 @@ use ArrayAccess;
 use Countable;
 use Serializable;
 
-class ClassName extends ParentClass implements
+class ClassNameMultiline extends ParentClass implements
     \ArrayAccess,
     \Countable,
     \Serializable

--- a/test/fixable/namespaces-spacing.php
+++ b/test/fixable/namespaces-spacing.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Foo;
+namespace   Foo;
 
 use DateInterval;
 use DateTimeImmutable;
@@ -16,3 +16,5 @@ strrev(
         ->sub(new DateInterval('P1D'))
         ->format(DATE_RFC3339)
 );
+
+// new \ Bar \ Baz();

--- a/test/fixable/new-with-parentheses.php
+++ b/test/fixable/new-with-parentheses.php
@@ -32,3 +32,6 @@ $e = $e ?? new stdClass;
 $response = (new Response())
     ->withStatus(200)
     ->withAddedHeader('Content-Type', 'text/plain');
+
+$anonymousClass = new class extends DateTime {
+};

--- a/test/fixable/not-spacing.php
+++ b/test/fixable/not-spacing.php
@@ -13,9 +13,17 @@ if (!$test > 0) {
 }
 
 while (    !    true) {
+
     echo 1;
+    // comment
+
 }
 
 do {
+
     echo 1;
+
 } while (    !    true);
+
+new  DateTime();
+new\DateTime();

--- a/test/fixable/operators.php
+++ b/test/fixable/operators.php
@@ -31,3 +31,7 @@ if (isset($foo)) {
 $fooBar = isset($foo, $bar) ? 'foo' : 'bar';
 
 $baz = ! isset($foo) ? 'foo' : 'baz';
+
+echo Something
+    ::
+    BAR;

--- a/test/fixable/variable-names.php
+++ b/test/fixable/variable-names.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+$globals = [
+    $_SERVER,
+    $_GET,
+    $_POST,
+    $_REQUEST,
+    $_SESSION,
+    $_ENV,
+    $_COOKIE,
+    $_FILES,
+    $GLOBALS,
+];
+
+$_underscoreOnTheBeginning = false;
+$not_a_camel_case          = false;
+$camelCase                 = true;
+$camel8number              = true;
+
+echo Library::$_variable;
+echo Library::$_another_variable;
+
+class VariableNames
+{
+    protected $_this_is_not_handled_by_this_sniff;
+}
+
+$string  = $_some_variable;
+$string .= $camelCase;

--- a/test/fixed/anonymous-classes.php
+++ b/test/fixed/anonymous-classes.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-$instance = new class {
+$instance = new class() {
 };
 
 // Brace on the same line
-$instance = new class extends Foo implements HandleableInterface {
+$instance = new class() extends Foo implements HandleableInterface {
     // Class content
 };
 
 // Brace on the next line
-$instance = new class extends Foo implements
+$instance = new class() extends Foo implements
     ArrayAccess,
     Countable,
     Serializable

--- a/test/fixed/class-properties.php
+++ b/test/fixed/class-properties.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+class ClassProperties
+{
+    public $var;
+
+    protected $bar;
+
+    private $baz;
+}

--- a/test/fixed/classes-traits-interfaces.php
+++ b/test/fixed/classes-traits-interfaces.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+class Foo
+{
+    public $bar;
+}
+
+trait Bar
+{
+    public $var;
+}
+
+interface Baz
+{
+    public function big() : int;
+}

--- a/test/fixed/control-structures.php
+++ b/test/fixed/control-structures.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+switch (true) {
+    case $a:
+        break;
+    case $b:
+        if ($a > 1) {
+            break;
+        }
+        break;
+}
+
+while ($a > 1) {
+    for ($i = $a; $i < $b; ++$i) {
+        if ($i % 2) {
+            continue;
+        }
+
+        break 2;
+    }
+}

--- a/test/fixed/extends-and-implements-multiline.php
+++ b/test/fixed/extends-and-implements-multiline.php
@@ -9,7 +9,7 @@ use Countable;
 use ParentClass;
 use Serializable;
 
-class ClassName extends ParentClass implements
+class ClassNameMultiline extends ParentClass implements
     ArrayAccess,
     Countable,
     Serializable

--- a/test/fixed/namespaces-spacing.php
+++ b/test/fixed/namespaces-spacing.php
@@ -18,3 +18,5 @@ strrev(
         ->sub(new DateInterval('P1D'))
         ->format(DATE_RFC3339)
 );
+
+// new \ Bar \ Baz();

--- a/test/fixed/new-with-parentheses.php
+++ b/test/fixed/new-with-parentheses.php
@@ -32,3 +32,6 @@ $e = $e ?? new stdClass();
 $response = (new Response())
     ->withStatus(200)
     ->withAddedHeader('Content-Type', 'text/plain');
+
+$anonymousClass = new class() extends DateTime {
+};

--- a/test/fixed/not-spacing.php
+++ b/test/fixed/not-spacing.php
@@ -14,8 +14,12 @@ if (! $test > 0) {
 
 while (! true) {
     echo 1;
+    // comment
 }
 
 do {
     echo 1;
 } while (! true);
+
+new DateTime();
+new DateTime();

--- a/test/fixed/operators.php
+++ b/test/fixed/operators.php
@@ -31,3 +31,5 @@ if (isset($foo)) {
 $fooBar = isset($foo, $bar) ? 'foo' : 'bar';
 
 $baz = ! isset($foo) ? 'foo' : 'baz';
+
+echo Something::BAR;

--- a/test/fixed/statement-alignment.php
+++ b/test/fixed/statement-alignment.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$shortVar        = (1 + 2);
+$shortVar        = 1 + 2;
 $veryLongVarName = 'string';
 
 $value  = (string) $value;

--- a/test/fixed/traits-uses.php
+++ b/test/fixed/traits-uses.php
@@ -12,11 +12,11 @@ class Foo
 class Bar
 {
     use FirstTrait;
+    use FourthTrait;
     use SecondTrait;
     use ThirdTrait {
         x as public;
     }
-    use FourthTrait;
 
     public function __construct()
     {

--- a/test/fixed/variable-names.php
+++ b/test/fixed/variable-names.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+$globals = [
+    $_SERVER,
+    $_GET,
+    $_POST,
+    $_REQUEST,
+    $_SESSION,
+    $_ENV,
+    $_COOKIE,
+    $_FILES,
+    $GLOBALS,
+];
+
+$_underscoreOnTheBeginning = false;
+$not_a_camel_case          = false;
+$camelCase                 = true;
+$camel8number              = true;
+
+echo Library::$_variable;
+echo Library::$_another_variable;
+
+class VariableNames
+{
+    protected $_this_is_not_handled_by_this_sniff;
+}
+
+$string  = $_some_variable;
+$string .= $camelCase;


### PR DESCRIPTION
I've started testing the library with webimpress/coding-standard to release version 1.0.0 of my library.
I've added several simple sniffs here which I have implemented and override some with my version, as these are more reliable or fixes more cases (please see tests).

There is one problem with spaces around namespace operators.
I wanted to include that sniff, but looks like one sniff from Slevomat library wrongly recognised references and do a fix file with invalid use import: `use ;` (it is only in first fix loop, then somehow it is removed, but it conflicts with other sniffs).