### PR TITLE
Added PHP 7.3 build and removed nightly in Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 php:
 - 7.1
 - 7.2
-- nightly
+- 7.3
 
 cache:
   directories:
@@ -25,9 +25,6 @@ stages:
   - Test
 
 jobs:
-  allow_failures:
-    - php: nightly
-
   include:
     - stage: Validate against schema
       addons:


### PR DESCRIPTION
We don't need to run the build on nightly PHP as it pins to PHP 7.4 which is very early stage.
We should check it on PHP 7.3 instead.