### PR TITLE
Double quote usage

### DIFF
--- a/docs/book/v2/ruleset.md
+++ b/docs/book/v2/ruleset.md
@@ -953,25 +953,26 @@ Force whitespace before and after concatenation
 
 ### Squiz.Strings.DoubleQuoteUsage
 #### Squiz.Strings.DoubleQuoteUsage.ContainsVar
-Double quote strings may only be used if they contain variables. SQL queries containing single quotes are an exception
+Double quote strings may only be used if they contain variables, control characters or if using single quotes would 
+result in more escaped characters than necessary. For instance, SQL queries containing single quotes are an exception
 to the rule.
 
-*Valid: Double quote strings are only used when it contains a variable.*
+*Valid: Double quote strings are only used when it contains a variable, control characters or single quotes.*
 ```php
 <?php
 $string = "Hello There\r\n";
 $string = "Hello $there";
 $string = 'Hello There';
-$string = 'Hello'.' There'."\n";
+$string = 'Hello' . ' There' . "\n";
 $string = '\$var';
 $query = "SELECT * FROM table WHERE name =''";
 ```
 
-*Invalid: There are no variables inside double quote strings.*
+*Invalid: There are no variables, control characters inside double quote strings*
 ```php
 <?php
 $string = "Hello There";
-$string = "Hello"." There"."\n";
+$string = "Hello" . " There" . "\n";
 $string = "\$var";
 ```
 

--- a/docs/book/v2/ruleset.md
+++ b/docs/book/v2/ruleset.md
@@ -963,12 +963,11 @@ to the rule.
 $string = "Hello There\r\n";
 $string = "Hello $there";
 $string = 'Hello There';
-$string = 'Hello' . ' There' . "\n";
 $string = '\$var';
 $query = "SELECT * FROM table WHERE name =''";
 ```
 
-*Invalid: There are no variables, control characters inside double quote strings*
+*Invalid: There are no variables or control characters inside double quote strings.*
 ```php
 <?php
 $string = "Hello There";

--- a/src/ZendCodingStandard/ruleset.xml
+++ b/src/ZendCodingStandard/ruleset.xml
@@ -384,9 +384,8 @@
         </properties>
     </rule>
     <!-- Forbid strings in `"` unless necessary -->
-    <rule ref="Squiz.Strings.DoubleQuoteUsage"/>
-    <rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
-        <message>Variable "%s" not allowed in double quoted string; use sprintf() or concatenation instead</message>
+    <rule ref="Squiz.Strings.DoubleQuoteUsage">
+        <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"></exclude>
     </rule>
     <!-- Forbid braces around string in `echo` -->
     <rule ref="Squiz.Strings.EchoedStrings"/>

--- a/test/expected-report.txt
+++ b/test/expected-report.txt
@@ -10,7 +10,7 @@ test/fixable/class-properties.php                     6       0
 test/fixable/classes-traits-interfaces.php            17      1
 test/fixable/closures.php                             19      0
 test/fixable/commenting.php                           26      0
-test/fixable/concatenation-spacing.php                21      0
+test/fixable/concatenation-spacing.php                19      0
 test/fixable/control-structures.php                   6       0
 test/fixable/example-class.php                        29      0
 test/fixable/extends-and-implements-multiline.php     13      0
@@ -30,6 +30,7 @@ test/fixable/return-type-on-methods.php               17      0
 test/fixable/semicolon-spacing.php                    5       0
 test/fixable/spacing.php                              18      1
 test/fixable/statement-alignment.php                  19      0
+test/fixable/strings-double-quote-usage.php           6       0
 test/fixable/test-case.php                            4       0
 test/fixable/traits-uses.php                          9       0
 test/fixable/UnusedVariables.php                      1       0
@@ -37,9 +38,9 @@ test/fixable/useless-semicolon.php                    8       0
 test/fixable/variable-names.php                       5       2
 test/fixable/visibility-declaration.php               1       0
 ----------------------------------------------------------------------
-A TOTAL OF 441 ERRORS AND 6 WARNINGS WERE FOUND IN 33 FILES
+A TOTAL OF 445 ERRORS AND 6 WARNINGS WERE FOUND IN 34 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 377 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 381 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/test/fixable/strings-double-quote-usage.php
+++ b/test/fixable/strings-double-quote-usage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+// valid
+$there  = 'There';
+$string = "Hello There\r\n";
+$string = "Hello $there";
+$string = 'Hello There';
+$string = '\$var';
+$query  = "SELECT * FROM table WHERE name =''";
+
+// invalid
+$string = "Hello There";
+$string = "Hello" . " There" . "\n";
+$string = "\$var";

--- a/test/fixed/strings-double-quote-usage.php
+++ b/test/fixed/strings-double-quote-usage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+// valid
+$there  = 'There';
+$string = "Hello There\r\n";
+$string = "Hello $there";
+$string = 'Hello There';
+$string = '\$var';
+$query  = "SELECT * FROM table WHERE name =''";
+
+// invalid
+$string = 'Hello There';
+$string = 'Hello' . ' There' . "\n";
+$string = '$var';


### PR DESCRIPTION
Squiz.Strings.DoubleQuoteUsage.ContainsVar prevents strings containing variables. This doesn't match the examples in the documentation and, given that PHP7s interpolation uses less memory than concatenation, probably isn't intended.

This PR adds an exclude for that check and tries to make the docs a little more exact.
